### PR TITLE
Add initialiser to clean values on replacement

### DIFF
--- a/Files/WACDSCustomMapping.h
+++ b/Files/WACDSCustomMapping.h
@@ -42,10 +42,10 @@ typedef NSDate* _Nonnull (^WACDSMappingExpirationDateBuilder)(id _Nonnull object
  *
  *  @return a fresh mapping
  */
-- (instancetype)initWithManagedObjectEntityName:(NSString *_Nonnull)objectEntityName
-                        uniqueIdentifierPattern:(NSString *_Nonnull)uniqueIdentifierPattern
-              searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder _Nonnull)searchableItemAttributeSetBuilder
-                       cleanValuesOnReplacement:(BOOL)cleanValuesOnReplacement;
+- (instancetype _Nonnull)initWithManagedObjectEntityName:(NSString *_Nonnull)objectEntityName
+                                 uniqueIdentifierPattern:(NSString *_Nonnull)uniqueIdentifierPattern
+                       searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder _Nonnull)searchableItemAttributeSetBuilder
+                                cleanValuesOnReplacement:(BOOL)cleanValuesOnReplacement;
 
 /**
  *  Get the unique identifier from an object based on the pattern

--- a/Files/WACDSCustomMapping.h
+++ b/Files/WACDSCustomMapping.h
@@ -33,6 +33,18 @@ typedef NSDate* _Nonnull (^WACDSMappingExpirationDateBuilder)(id _Nonnull object
                        searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder _Nonnull)searchableItemAttributeSetBuilder;
 
 /**
+ *  Init the mapping
+ *
+ *  @param objectEntityName                  The object entity name
+ *  @param uniqueIdentifierPattern           A pattern for unique identifier. Ex: booking_{#bookingID#}
+ *  @param searchableItemAttributeSetBuilder A block which will be called for each object to index. You need to return an attribute set
+ *  @param cleanValuesOnReplacement          A bool which is used to change the default behaviour. By default is NO.
+ *
+ *  @return a fresh mapping
+ */
+- (instancetype)initWithManagedObjectEntityName:(NSString *)objectEntityName uniqueIdentifierPattern:(NSString *)uniqueIdentifierPattern searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder)searchableItemAttributeSetBuilder cleanValuesOnReplacement:(BOOL)cleanValuesOnReplacement;
+
+/**
  *  Get the unique identifier from an object based on the pattern
  *
  *  @param object the object you want to index

--- a/Files/WACDSCustomMapping.h
+++ b/Files/WACDSCustomMapping.h
@@ -42,7 +42,10 @@ typedef NSDate* _Nonnull (^WACDSMappingExpirationDateBuilder)(id _Nonnull object
  *
  *  @return a fresh mapping
  */
-- (instancetype)initWithManagedObjectEntityName:(NSString *)objectEntityName uniqueIdentifierPattern:(NSString *)uniqueIdentifierPattern searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder)searchableItemAttributeSetBuilder cleanValuesOnReplacement:(BOOL)cleanValuesOnReplacement;
+- (instancetype)initWithManagedObjectEntityName:(NSString *_Nonnull)objectEntityName
+                        uniqueIdentifierPattern:(NSString *_Nonnull)uniqueIdentifierPattern
+              searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder _Nonnull)searchableItemAttributeSetBuilder
+                       cleanValuesOnReplacement:(BOOL)cleanValuesOnReplacement;
 
 /**
  *  Get the unique identifier from an object based on the pattern

--- a/Files/WACDSCustomMapping.m
+++ b/Files/WACDSCustomMapping.m
@@ -26,6 +26,10 @@
 @implementation WACDSCustomMapping
 
 - (instancetype)initWithManagedObjectEntityName:(NSString *)objectEntityName uniqueIdentifierPattern:(NSString *)uniqueIdentifierPattern searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder)searchableItemAttributeSetBuilder {
+    return [self initWithManagedObjectEntityName:objectEntityName uniqueIdentifierPattern:uniqueIdentifierPattern searchableItemAttributeSetBuilder:searchableItemAttributeSetBuilder cleanValuesOnReplacement:NO];
+}
+
+- (instancetype)initWithManagedObjectEntityName:(NSString *)objectEntityName uniqueIdentifierPattern:(NSString *)uniqueIdentifierPattern searchableItemAttributeSetBuilder:(WACDSSearchableItemAttributeSetBuilder)searchableItemAttributeSetBuilder cleanValuesOnReplacement:(BOOL)cleanValuesOnReplacement {
     
     WACDSClassAssertion(objectEntityName, NSString);
     WACDSClassAssertion(uniqueIdentifierPattern, NSString);
@@ -37,7 +41,7 @@
         self->_searchableItemAttributeSetBuilder = searchableItemAttributeSetBuilder;
         
         // Create the pattern
-        self->_uniqueIdentifierStringPattern = [[WACDSStringPattern alloc] initWithPattern:uniqueIdentifierPattern cleanValuesOnReplacement:NO];
+        self->_uniqueIdentifierStringPattern = [[WACDSStringPattern alloc] initWithPattern:uniqueIdentifierPattern cleanValuesOnReplacement:cleanValuesOnReplacement];
     }
     
     return self;


### PR DESCRIPTION
With the SimpleMapping the cleanValuesOnReplacement is set to YES/NO for uniqueIdentifier according the conditions but in the CustomMapping is always set to NO.